### PR TITLE
Skip invalid cluster-backgrounbackground paths, bump 3.2.1

### DIFF
--- a/ios/Classes/TiGooglemapsView.m
+++ b/ios/Classes/TiGooglemapsView.m
@@ -78,7 +78,14 @@
         
         for (id background in clusterBackgrounds) {
             ENSURE_TYPE(background, NSString);
-            [backgrounds addObject:[TiUtils image:background proxy:self.proxy]];
+            UIImage *clusterBackground = [TiUtils image:background proxy:self.proxy];
+            
+            if (!clusterBackground) {
+                NSLog(@"[ERROR] Cluster background-file (%@) cannot be found, skipping ...");
+                continue;
+            }
+            
+            [backgrounds addObject:clusterBackground];
         }
         
         return [[TiClusterIconGenerator alloc] initWithBuckets:clusterRanges backgroundImages:backgrounds];

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.2.0
+version: 3.2.1
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: ti.googlemaps

--- a/ios/module.xcconfig
+++ b/ios/module.xcconfig
@@ -6,7 +6,7 @@
 // for this file:
 // http://developer.apple.com/mac/library/documentation/DeveloperTools/Conceptual/XcodeBuildSystem/400-Build_Configurations/build_configs.html
 //
-FRAMEWORK_SEARCH_PATHS=$(SRCROOT)/../../modules/iphone/ti.googlemaps/3.2.0/platform "~/Library/Application\ Support/Titanium/modules/iphone/ti.googlemaps/3.2.0/platform"
+FRAMEWORK_SEARCH_PATHS=$(SRCROOT)/../../modules/iphone/ti.googlemaps/3.2.1/platform "~/Library/Application\ Support/Titanium/modules/iphone/ti.googlemaps/3.2.1/platform"
 
 OTHER_LDFLAGS = $(inherited) -framework Accelerate -framework AVFoundation -framework CoreBluetooth -framework CoreData -framework CoreGraphics -framework CoreLocation -framework CoreText -framework GLKit -framework ImageIO -lobjc -lc++ -lz -licucore -framework OpenGLES -framework QuartzCore -framework Security -framework SystemConfiguration -framework GoogleMaps -framework GoogleMapsBase -framework GoogleMapsCore -framework GooglePlaces
 


### PR DESCRIPTION
Fixes https://github.com/hansemannn/ti.googlemaps/issues/77